### PR TITLE
Ensure config dir exists

### DIFF
--- a/brightness/config.go
+++ b/brightness/config.go
@@ -37,6 +37,9 @@ func NewConfig() *Config {
 }
 
 func (cfg *Config) OpenConfigFile() error {
+	if err := os.MkdirAll(filepath.Dir(cfg.ConfigFile), 0o755); err != nil {
+		return fmt.Errorf("error ensuring config directory: %v", err)
+	}
 	file, err := os.OpenFile(cfg.ConfigFile, os.O_RDWR, 0766)
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/brightness/config_test.go
+++ b/brightness/config_test.go
@@ -1,0 +1,26 @@
+package brightness
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenConfigFileCreatesDir(t *testing.T) {
+	root := t.TempDir()
+	cfgPath := filepath.Join(root, "newdir", "config.json")
+
+	if _, err := os.Stat(filepath.Dir(cfgPath)); !os.IsNotExist(err) {
+		t.Fatalf("expected directory to not exist before call: %v", err)
+	}
+
+	cfg := &Config{ConfigFile: cfgPath, Device: "HDMI-1-2"}
+	if err := cfg.OpenConfigFile(); err != nil {
+		t.Fatalf("OpenConfigFile returned error: %v", err)
+	}
+	defer cfg.File.Close()
+
+	if _, err := os.Stat(filepath.Dir(cfgPath)); err != nil {
+		t.Fatalf("expected directory to exist after call: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure brightness config directory exists before opening file
- test that directory creation occurs when not present

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6859450acb08832bb1b904eb47f40827