### PR TITLE
Clamp brightness values within bounds

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,13 @@ func Refresh() error {
 
 func Increase() error {
 	newValue := cfg.LastAppliedBrightness + cfg.Increase
+	if newValue > 1 {
+		logrus.Warnf("Calculated brightness %f exceeds maximum; clamping to 1", newValue)
+		newValue = 1
+	} else if newValue < 0 {
+		logrus.Warnf("Calculated brightness %f below minimum; clamping to 0", newValue)
+		newValue = 0
+	}
 	logrus.Infof("Increasing brightness by %f, to %f", cfg.Increase, newValue)
 	cmd := exec.Command(
 		"xrandr", "--output", cfg.Device,
@@ -39,6 +46,13 @@ func Increase() error {
 
 func Decrease() error {
 	newValue := cfg.LastAppliedBrightness - cfg.Decrease
+	if newValue > 1 {
+		logrus.Warnf("Calculated brightness %f exceeds maximum; clamping to 1", newValue)
+		newValue = 1
+	} else if newValue < 0 {
+		logrus.Warnf("Calculated brightness %f below minimum; clamping to 0", newValue)
+		newValue = 0
+	}
 	logrus.Infof("Decreasing brightness by %f, to %f", cfg.Decrease, newValue)
 	cmd := exec.Command(
 		"xrandr", "--output", cfg.Device,

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/umutozd/brightness-controller/brightness"
+)
+
+func setupTest(t *testing.T) (cleanup func()) {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	// stub xrandr binary
+	stub := filepath.Join(tmpDir, "xrandr")
+	if err := ioutil.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+
+	cfg = brightness.NewConfig()
+	cfg.ConfigFile = filepath.Join(tmpDir, "config.json")
+	cfg.Device = "HDMI-1-2"
+	if err := cfg.OpenConfigFile(); err != nil {
+		t.Fatal(err)
+	}
+
+	return func() {
+		cfg.File.Close()
+		os.Setenv("PATH", oldPath)
+	}
+}
+
+func captureLogs() (*bytes.Buffer, func()) {
+	buf := new(bytes.Buffer)
+	logger := logrus.StandardLogger()
+	oldOut := logger.Out
+	oldLevel := logger.Level
+	logger.Out = buf
+	logger.SetLevel(logrus.WarnLevel)
+	return buf, func() {
+		logger.Out = oldOut
+		logger.SetLevel(oldLevel)
+	}
+}
+
+func TestIncreaseClampsAboveOne(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+	cfg.LastAppliedBrightness = 0.95
+	cfg.Increase = 0.1
+
+	buf, restore := captureLogs()
+	defer restore()
+
+	if err := Increase(); err != nil {
+		t.Fatalf("Increase returned error: %v", err)
+	}
+
+	if cfg.LastAppliedBrightness != 1 {
+		t.Errorf("expected brightness to be clamped to 1, got %v", cfg.LastAppliedBrightness)
+	}
+
+	if !strings.Contains(buf.String(), "clamping") {
+		t.Errorf("expected warning about clamping, got logs: %s", buf.String())
+	}
+}
+
+func TestDecreaseClampsBelowZero(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+	cfg.LastAppliedBrightness = 0.05
+	cfg.Decrease = 0.1
+
+	buf, restore := captureLogs()
+	defer restore()
+
+	if err := Decrease(); err != nil {
+		t.Fatalf("Decrease returned error: %v", err)
+	}
+
+	if cfg.LastAppliedBrightness != 0 {
+		t.Errorf("expected brightness to be clamped to 0, got %v", cfg.LastAppliedBrightness)
+	}
+
+	if !strings.Contains(buf.String(), "clamping") {
+		t.Errorf("expected warning about clamping, got logs: %s", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- prevent brightness values from going beyond `[0,1]`
- log warnings when clamping occurs
- add tests for clamping behavior

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68594521b478832bad58626728e12c3c