### PR TITLE
Show help if no flags provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,8 @@ func Run(ctx *cli.Context) error {
 		return Decrease()
 	}
 
+	// no actionable flags were provided
+	cli.ShowAppHelp(ctx)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- display usage info when no actionable flags are supplied

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685945335eb8832b91eeee2efa501c31